### PR TITLE
fixed server port

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ import bcrypt from 'bcrypt';
 
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 const router = express.Router();
 
 app.set('view engine', 'ejs');


### PR DESCRIPTION
I added a process.env.PORT option on our server so that our server can use the hosting services' listening port since they all have different onces.